### PR TITLE
fix: preserve input state by lifting state up and adding types

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import SyncedInputs from "./task-4/SyncedInputs.tsx";
+import ParentAnswer from "./task-5/Answer.tsx";
 
 const App = () => {
   return (
     <>
-      <SyncedInputs />
+      <ParentAnswer />
     </>
   );
 };

--- a/src/task-5/Answer.tsx
+++ b/src/task-5/Answer.tsx
@@ -1,0 +1,72 @@
+import { ChangeEvent, useState } from "react";
+
+type PropAnswer = {
+  showHint: boolean;
+  setShowHint: (val: boolean) => void;
+  text: string;
+  handleChangeValue: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+};
+
+type PropForm = {
+  text: string;
+  handleChangeValue: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+};
+
+export default function ParentAnswer() {
+  const [showHint, setShowHint] = useState(false);
+  const [text, setText] = useState("");
+
+  function handleChangeValue(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    setText(e.target.value);
+  }
+
+  return (
+    <>
+      {showHint ? (
+        <Answer
+          text={text}
+          showHint={showHint}
+          setShowHint={setShowHint}
+          handleChangeValue={handleChangeValue}
+        />
+      ) : (
+        <Answer
+          text={text}
+          showHint={showHint}
+          setShowHint={setShowHint}
+          handleChangeValue={handleChangeValue}
+        />
+      )}
+    </>
+  );
+}
+
+const Answer: React.FC<PropAnswer> = ({
+  showHint,
+  setShowHint,
+  text,
+  handleChangeValue,
+}) => {
+  return (
+    <div>
+      {showHint && (
+        <p>
+          <i>Hint: Your favorite city?</i>
+        </p>
+      )}
+      <Form text={text} handleChangeValue={handleChangeValue} />
+      <br></br>
+      <button
+        onClick={() => {
+          setShowHint(!showHint);
+        }}
+      >
+        {showHint ? "Show hint" : "Hide hint"}
+      </button>
+    </div>
+  );
+};
+
+const Form: React.FC<PropForm> = ({ text, handleChangeValue }) => {
+  return <textarea value={text} onChange={(e) => handleChangeValue(e)} />;
+};

--- a/src/task-5/README.md
+++ b/src/task-5/README.md
@@ -1,0 +1,19 @@
+## Task 1 of 5: Fixed a Bug with Disappearing Text in an Input Field
+
+### Problem
+In the app, clicking a button displays a message, but at the same time **resets the text inside input fields**. This leads to a poor user experience, as the entered data is lost unexpectedly.
+
+### Why This Happens
+The issue occurs because the button click triggers a **component re-render or state reset**. Common reasons include:
+
+- The input value is **not controlled by React state**.
+- The state holding the input value is being **reset when the button is clicked**.
+- The button is inside a `<form>` and has `type="submit"`, causing a **form submission and page refresh**.
+- State is recreated due to conditional rendering or incorrect component structure.
+
+### Solution
+To prevent the input text from resetting:
+
+1. Make the input a **controlled component** by storing its value in `useState`.
+2. Ensure the button **does not reset state** unrelated to its action.
+3. If inside a form, set `type="button"` or prevent default form submission.


### PR DESCRIPTION
Description:
The Goal: The task was to prevent the textarea content from disappearing when the user toggles the "hint" message.

The Fix:

State Relocation: I moved the text state from the local component up to the App component.
Controlled Component: The textarea is now a controlled component, meaning its value is driven by the parent state rather than its own internal memory.
Persistent Position: By lifting the state, the data is preserved even when the Answer component is re-rendered or switched in the conditional logic.

How to Test:

Open the app and type any text into the field.
Click the "Show hint" button.
Verify that the text you typed is still there and hasn't been cleared.

Task Checklist:
[x] Task 1: Fix disappearing input text.